### PR TITLE
#87 Updated Main Library to 1.7.1.6 beta

### DIFF
--- a/BSMyGunCollection.UnitTest/BSMyGunCollection.UnitTest.csproj
+++ b/BSMyGunCollection.UnitTest/BSMyGunCollection.UnitTest.csproj
@@ -42,8 +42,8 @@
     <Reference Include="Appium.Net, Version=4.3.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Appium.WebDriver.4.3.1\lib\net45\Appium.Net.dll</HintPath>
     </Reference>
-    <Reference Include="BurnSoft.Applications.MGC, Version=1.7.0.4, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BurnSoft.Applications.MGC.1.7.0.4\lib\net472\BurnSoft.Applications.MGC.dll</HintPath>
+    <Reference Include="BurnSoft.Applications.MGC, Version=1.7.1.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BurnSoft.Applications.MGC.1.7.1.6-beta\lib\net472\BurnSoft.Applications.MGC.dll</HintPath>
     </Reference>
     <Reference Include="BurnSoft.MsgBox, Version=2.2.355.3458, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\BurnSoft.MsgBox.2.2.355.3458\lib\net472\BurnSoft.MsgBox.dll</HintPath>

--- a/BSMyGunCollection.UnitTest/packages.config
+++ b/BSMyGunCollection.UnitTest/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Appium.WebDriver" version="4.3.1" targetFramework="net48" />
-  <package id="BurnSoft.Applications.MGC" version="1.7.0.4" targetFramework="net48" />
+  <package id="BurnSoft.Applications.MGC" version="1.7.1.6-beta" targetFramework="net48" />
   <package id="BurnSoft.MsgBox" version="2.2.355.3458" targetFramework="net48" />
   <package id="BurnSoft.Security.RegularEncryption" version="1.0.0" targetFramework="net48" />
   <package id="BurnSoft.Testing.Apps.Appium" version="1.0.0.12-RC1" targetFramework="net48" />

--- a/BSMyGunCollection/BSMyGunCollection.vbproj
+++ b/BSMyGunCollection/BSMyGunCollection.vbproj
@@ -126,8 +126,8 @@
     <ManifestTimestampUrl>http://timestamp.verisign.com/scripts/timstamp.dll</ManifestTimestampUrl>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BurnSoft.Applications.MGC, Version=1.7.0.4, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BurnSoft.Applications.MGC.1.7.0.4\lib\net472\BurnSoft.Applications.MGC.dll</HintPath>
+    <Reference Include="BurnSoft.Applications.MGC, Version=1.7.1.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BurnSoft.Applications.MGC.1.7.1.6-beta\lib\net472\BurnSoft.Applications.MGC.dll</HintPath>
     </Reference>
     <Reference Include="BurnSoft.MsgBox, Version=2.2.355.3458, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\BurnSoft.MsgBox.2.2.355.3458\lib\net472\BurnSoft.MsgBox.dll</HintPath>

--- a/BSMyGunCollection/packages.config
+++ b/BSMyGunCollection/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BurnSoft.Applications.MGC" version="1.7.0.4" targetFramework="net472" />
+  <package id="BurnSoft.Applications.MGC" version="1.7.1.6-beta" targetFramework="net472" />
   <package id="BurnSoft.MsgBox" version="2.2.355.3458" targetFramework="net472" />
   <package id="BurnSoft.Security.RegularEncryption" version="1.0.0" targetFramework="net472" />
   <package id="BurnSoft.Universal" version="4.0.32.5" targetFramework="net472" />


### PR DESCRIPTION
The Library Update fixed the error, since the error was corrected in the library.  The default barrel is added in so it will always return 1 while the function was looking for 0 so it was changed to 1, if there is something greater than 1 then it has more than the default.